### PR TITLE
added API endpoint /container/list

### DIFF
--- a/packages/code_api/actions/container/list.py
+++ b/packages/code_api/actions/container/list.py
@@ -1,0 +1,26 @@
+from typing import List
+
+import docker.errors
+from docker.models.containers import Container
+from flask import Blueprint
+
+from code_api.utils import response_ok, get_client, response_error
+
+
+container_list = Blueprint('container_list', __name__)
+__all__ = ['list']
+
+
+@container_list.route('/container/list')
+def _list():
+    # get docker client
+    client = get_client()
+    # get list of docker container names
+    try:
+        list_container = client.containers.list()
+        list_container_names = [c.attrs['Name'] for c in list_container]
+        # return status
+        return response_ok({'list_running_containers': list_container_names})
+    except (docker.errors.APIError, KeyError) as e:
+        return response_error(f"Error: {str(e)}")
+        

--- a/packages/code_api/actions/container/list.py
+++ b/packages/code_api/actions/container/list.py
@@ -17,7 +17,7 @@ def _list():
     client = get_client()
     # get list of docker container names
     try:
-        list_container = client.containers.list()
+        list_container: List[Container] = client.containers.list()
         list_container_names = [c.attrs['Name'] for c in list_container]
         # return status
         return response_ok({'list_running_containers': list_container_names})

--- a/packages/code_api/actions/container/list.py
+++ b/packages/code_api/actions/container/list.py
@@ -20,7 +20,7 @@ def _list():
         list_container: List[Container] = client.containers.list()
         list_container_names = [c.attrs['Name'] for c in list_container]
         # return status
-        return response_ok({'list_running_containers': list_container_names})
+        return response_ok({'containers': list_container_names})
     except (docker.errors.APIError, KeyError) as e:
         return response_error(f"Error: {str(e)}")
         

--- a/packages/code_api/api.py
+++ b/packages/code_api/api.py
@@ -15,6 +15,7 @@ from .actions.container.run import run as container_run
 from .actions.container.status import status as container_status
 from .actions.container.logs import logs as container_logs
 from .actions.container.generic import generic as container_generic
+from .actions.container.list import container_list
 
 
 class CodeAPI(Flask):
@@ -32,6 +33,7 @@ class CodeAPI(Flask):
         # register blueprints (/container/*)
         self.register_blueprint(container_run)
         self.register_blueprint(container_status)
+        self.register_blueprint(container_list)
         self.register_blueprint(container_logs)
         self.register_blueprint(container_generic)
         # apply CORS settings


### PR DESCRIPTION
This PR adds an endpoint to fetch the list of running containers. It facilitates the logs downloading endpoint, given that the container names are not fixed, especially when developers run `dts devel run ...`.