### PR TITLE
Add container list endpoint and register blueprint

### DIFF
--- a/packages/code_api/actions/container/list.py
+++ b/packages/code_api/actions/container/list.py
@@ -1,0 +1,26 @@
+from typing import List
+
+import docker.errors
+from docker.models.containers import Container
+from flask import Blueprint
+
+from code_api.utils import response_ok, get_client, response_error
+
+
+container_list = Blueprint('container_list', __name__)
+__all__ = ['list']
+
+
+@container_list.route('/container/list')
+def _list():
+    # get docker client
+    client = get_client()
+    # get list of docker container names
+    try:
+        list_container = client.containers.list()
+        list_container_names = [c.attrs['Name'] for c in list_container]
+        # return status
+        return response_ok({'list_running_containers': list_container_names})
+    except (docker.errors.APIError, KeyError) as e:
+        return response_error(f"Error: {str(e)}")
+        

--- a/packages/code_api/actions/container/list.py
+++ b/packages/code_api/actions/container/list.py
@@ -17,7 +17,7 @@ def _list():
     client = get_client()
     # get list of docker container names
     try:
-        list_container = client.containers.list()
+        list_container: List[Container] = client.containers.list()
         list_container_names = [c.attrs['Name'] for c in list_container]
         # return status
         return response_ok({'list_running_containers': list_container_names})

--- a/packages/code_api/actions/container/list.py
+++ b/packages/code_api/actions/container/list.py
@@ -20,7 +20,7 @@ def _list():
         list_container: List[Container] = client.containers.list()
         list_container_names = [c.attrs['Name'] for c in list_container]
         # return status
-        return response_ok({'list_running_containers': list_container_names})
+        return response_ok({'containers': list_container_names})
     except (docker.errors.APIError, KeyError) as e:
         return response_error(f"Error: {str(e)}")
         

--- a/packages/code_api/api.py
+++ b/packages/code_api/api.py
@@ -15,6 +15,7 @@ from .actions.container.run import run as container_run
 from .actions.container.status import status as container_status
 from .actions.container.logs import logs as container_logs
 from .actions.container.generic import generic as container_generic
+from .actions.container.list import container_list
 
 from .actions.stack.up import up as stack_up
 from .actions.stack.down import down as stack_down
@@ -36,6 +37,7 @@ class CodeAPI(Flask):
         # register blueprints (/container/*)
         self.register_blueprint(container_run)
         self.register_blueprint(container_status)
+        self.register_blueprint(container_list)
         self.register_blueprint(container_logs)
         self.register_blueprint(container_generic)
         # register blueprints (/stack/*)


### PR DESCRIPTION
This pull request adds a new API endpoint for listing Docker containers and integrates it into the application's Flask blueprint registration. The main changes are the introduction of the `/container/list` route and its registration in the main API.

**New container listing endpoint:**

* Added a new Flask blueprint `container_list` in `list.py` that provides a `/container/list` route to return the names of all Docker containers using the Docker SDK.

**API integration:**

* Registered the new `container_list` blueprint in `api.py`, making the new endpoint available as part of the API. [[1]](diffhunk://#diff-1fa3abf3a8fc26944b9a0a833cfffa19b7e56556105f3e62280194211678f2d5R16) [[2]](diffhunk://#diff-1fa3abf3a8fc26944b9a0a833cfffa19b7e56556105f3e62280194211678f2d5R40)